### PR TITLE
Feature/kiosk new design

### DIFF
--- a/Classes/MYNStickyFlowLayout.h
+++ b/Classes/MYNStickyFlowLayout.h
@@ -8,6 +8,14 @@
 
 #import <UIKit/UIKit.h>
 
+@protocol PKResizableHeaderDelegate <NSObject>
+
+- (void)sectionHeaderResizedToHeight:(CGFloat)height;
+
+@end
+
 @interface MYNStickyFlowLayout : UICollectionViewFlowLayout
+
+@property (nonatomic, weak) id<PKResizableHeaderDelegate>resizableHeaderDelegate;
 
 @end

--- a/Classes/MYNStickyFlowLayout.h
+++ b/Classes/MYNStickyFlowLayout.h
@@ -19,4 +19,7 @@
 
 @property (nonatomic, weak) id<PKResizableHeaderDelegate>resizableHeaderDelegate;
 
+@property (nonatomic, assign) NSUInteger minSectionHeaderHeight;
+@property (nonatomic, assign) NSUInteger minSectionHeaderWidth;
+
 @end

--- a/Classes/MYNStickyFlowLayout.h
+++ b/Classes/MYNStickyFlowLayout.h
@@ -11,6 +11,7 @@
 @protocol PKResizableHeaderDelegate <NSObject>
 
 - (void)sectionHeaderResizedToHeight:(CGFloat)height;
+- (void)sectionHeaderResizedToWidth:(CGFloat)width;
 
 @end
 

--- a/Classes/MYNStickyFlowLayout.m
+++ b/Classes/MYNStickyFlowLayout.m
@@ -8,37 +8,8 @@
 
 #import "MYNStickyFlowLayout.h"
 
-@interface MYNStickyFlowLayout ()
-
-@property (nonatomic, strong) NSMutableArray* indexPathsToAnimate;
-
-@property (nonatomic, strong) NSMutableDictionary* currentCellAttributes;
-@property (nonatomic, strong) NSMutableDictionary* cachedCellAttributes;
-
-@property (nonatomic, strong) NSMutableArray* insertedIndexPaths;
-@property (nonatomic, strong) NSMutableArray* removedIndexPaths;
-
-@end
 
 @implementation MYNStickyFlowLayout
-
-- (id)init {
-    self = [super init];
-    if (self) {
-        self.currentCellAttributes = [NSMutableDictionary dictionary];
-    }
-    return self;
-}
-
-
-#pragma mark - subclassing layout
-
-- (void)prepareLayout {
-    [super prepareLayout];
-    
-    self.cachedCellAttributes = [[NSMutableDictionary alloc] initWithDictionary:self.currentCellAttributes copyItems:YES];
-}
-
 
 - (NSArray *)layoutAttributesForElementsInRect:(CGRect)rect {
     NSMutableArray *allItems = [[super layoutAttributesForElementsInRect:rect] mutableCopy];
@@ -76,11 +47,6 @@
 
         // For iOS 7.0, the cell zIndex should be above sticky section header
         attributes.zIndex = 1;
-        
-        if (attributes.representedElementCategory == UICollectionElementCategoryCell) {
-            [self.currentCellAttributes setObject:attributes
-                                           forKey:attributes.indexPath];
-        }
     }];
 
     [lastCells enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
@@ -126,61 +92,6 @@
 - (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds {
     return YES;
 }
-
-
-#pragma mark - subclassing animation
-
-- (void)prepareForCollectionViewUpdates:(NSArray *)updateItems {
-    [super prepareForCollectionViewUpdates:updateItems];
-    
-    self.insertedIndexPaths = [NSMutableArray array];
-    self.removedIndexPaths = [NSMutableArray array];
-    
-    for (UICollectionViewUpdateItem *updateItem in updateItems) {
-        switch (updateItem.updateAction) {
-            case UICollectionUpdateActionInsert:
-                [self.insertedIndexPaths addObject:updateItem.indexPathAfterUpdate];
-                break;
-            case UICollectionUpdateActionDelete:
-                [self.removedIndexPaths addObject:updateItem.indexPathBeforeUpdate];
-                break;
-            default:
-                break;
-        }
-    }
-}
-
-- (UICollectionViewLayoutAttributes *)initialLayoutAttributesForAppearingItemAtIndexPath:(NSIndexPath *)itemIndexPath {
-    UICollectionViewLayoutAttributes* attributes = [self layoutAttributesForItemAtIndexPath:itemIndexPath];
-    
-    if ([self.insertedIndexPaths containsObject:itemIndexPath]) {
-        attributes = [[self.currentCellAttributes objectForKey:itemIndexPath] copy];
-        attributes.alpha = 0;
-    }
-    
-    return attributes;
-}
-
-
--(UICollectionViewLayoutAttributes *)finalLayoutAttributesForDisappearingItemAtIndexPath:(NSIndexPath *)itemIndexPath{
-    
-    UICollectionViewLayoutAttributes* attributes = [self layoutAttributesForItemAtIndexPath:itemIndexPath];
-    
-    if ([self.removedIndexPaths containsObject:itemIndexPath]) {
-        attributes = [[self.cachedCellAttributes objectForKey:itemIndexPath] copy];
-        attributes.alpha = 0;
-    }
-    
-    return attributes;
-}
-
-- (void)finalizeCollectionViewUpdates {
-    [super finalizeCollectionViewUpdates];
-    
-    self.insertedIndexPaths = nil;
-    self.removedIndexPaths = nil;
-}
-
 
 #pragma mark Helper
 

--- a/Classes/MYNStickyFlowLayout.m
+++ b/Classes/MYNStickyFlowLayout.m
@@ -8,10 +8,39 @@
 
 #import "MYNStickyFlowLayout.h"
 
+@interface MYNStickyFlowLayout ()
+
+@property (nonatomic, strong) NSMutableArray* indexPathsToAnimate;
+
+@property (nonatomic, strong) NSMutableDictionary* currentCellAttributes;
+@property (nonatomic, strong) NSMutableDictionary* cachedCellAttributes;
+
+@property (nonatomic, strong) NSMutableArray* insertedIndexPaths;
+@property (nonatomic, strong) NSMutableArray* removedIndexPaths;
+
+@end
+
 @implementation MYNStickyFlowLayout
 
-- (NSArray *)layoutAttributesForElementsInRect:(CGRect)rect
-{
+- (id)init {
+    self = [super init];
+    if (self) {
+        self.currentCellAttributes = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
+
+
+#pragma mark - subclassing layout
+
+- (void)prepareLayout {
+    [super prepareLayout];
+    
+    self.cachedCellAttributes = [[NSMutableDictionary alloc] initWithDictionary:self.currentCellAttributes copyItems:YES];
+}
+
+
+- (NSArray *)layoutAttributesForElementsInRect:(CGRect)rect {
     NSMutableArray *allItems = [[super layoutAttributesForElementsInRect:rect] mutableCopy];
 
     NSMutableDictionary *headers = [[NSMutableDictionary alloc] init];
@@ -47,6 +76,11 @@
 
         // For iOS 7.0, the cell zIndex should be above sticky section header
         attributes.zIndex = 1;
+        
+        if (attributes.representedElementCategory == UICollectionElementCategoryCell) {
+            [self.currentCellAttributes setObject:attributes
+                                           forKey:attributes.indexPath];
+        }
     }];
 
     [lastCells enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
@@ -89,10 +123,64 @@
     return allItems;
 }
 
-- (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds
-{
+- (BOOL)shouldInvalidateLayoutForBoundsChange:(CGRect)newBounds {
     return YES;
 }
+
+
+#pragma mark - subclassing animation
+
+- (void)prepareForCollectionViewUpdates:(NSArray *)updateItems {
+    [super prepareForCollectionViewUpdates:updateItems];
+    
+    self.insertedIndexPaths = [NSMutableArray array];
+    self.removedIndexPaths = [NSMutableArray array];
+    
+    for (UICollectionViewUpdateItem *updateItem in updateItems) {
+        switch (updateItem.updateAction) {
+            case UICollectionUpdateActionInsert:
+                [self.insertedIndexPaths addObject:updateItem.indexPathAfterUpdate];
+                break;
+            case UICollectionUpdateActionDelete:
+                [self.removedIndexPaths addObject:updateItem.indexPathBeforeUpdate];
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+- (UICollectionViewLayoutAttributes *)initialLayoutAttributesForAppearingItemAtIndexPath:(NSIndexPath *)itemIndexPath {
+    UICollectionViewLayoutAttributes* attributes = [self layoutAttributesForItemAtIndexPath:itemIndexPath];
+    
+    if ([self.insertedIndexPaths containsObject:itemIndexPath]) {
+        attributes = [[self.currentCellAttributes objectForKey:itemIndexPath] copy];
+        attributes.alpha = 0;
+    }
+    
+    return attributes;
+}
+
+
+-(UICollectionViewLayoutAttributes *)finalLayoutAttributesForDisappearingItemAtIndexPath:(NSIndexPath *)itemIndexPath{
+    
+    UICollectionViewLayoutAttributes* attributes = [self layoutAttributesForItemAtIndexPath:itemIndexPath];
+    
+    if ([self.removedIndexPaths containsObject:itemIndexPath]) {
+        attributes = [[self.cachedCellAttributes objectForKey:itemIndexPath] copy];
+        attributes.alpha = 0;
+    }
+    
+    return attributes;
+}
+
+- (void)finalizeCollectionViewUpdates {
+    [super finalizeCollectionViewUpdates];
+    
+    self.insertedIndexPaths = nil;
+    self.removedIndexPaths = nil;
+}
+
 
 #pragma mark Helper
 

--- a/Classes/MYNStickyFlowLayout.m
+++ b/Classes/MYNStickyFlowLayout.m
@@ -10,7 +10,8 @@
 
 NSUInteger minSectionHeaderHeightIpad = 114;
 NSUInteger minSectionHeaderHeightIphone = 85;
-NSUInteger minSectionHeaderWidth = 550/2;
+NSUInteger minSectionHeaderWidthIpad = 550/2;
+NSUInteger minSectionHeaderWidthIphone = 339/2;
 
 @implementation MYNStickyFlowLayout
 
@@ -130,19 +131,17 @@ NSUInteger minSectionHeaderWidth = 550/2;
         };
         
         NSUInteger minSectionHeaderHeight = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? minSectionHeaderHeightIpad : minSectionHeaderHeightIphone;
-        if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-            if (self.collectionView.contentOffset.y > 0) {
-                CGRect rect = attributes.frame;
-                rect.size.height -= self.collectionView.contentOffset.y;
-                if (rect.size.height >= minSectionHeaderHeight) {
-                    attributes.frame = rect;
-                } else {
-                    rect.size.height = minSectionHeaderHeight;
-                    attributes.frame = rect;
-                }
+        if (self.collectionView.contentOffset.y > 0) {
+            CGRect rect = attributes.frame;
+            rect.size.height -= self.collectionView.contentOffset.y;
+            if (rect.size.height >= minSectionHeaderHeight) {
+                attributes.frame = rect;
+            } else {
+                rect.size.height = minSectionHeaderHeight;
+                attributes.frame = rect;
             }
-            [self.resizableHeaderDelegate sectionHeaderResizedToHeight:attributes.frame.size.height];
         }
+        [self.resizableHeaderDelegate sectionHeaderResizedToHeight:attributes.frame.size.height];
     } else {
         attributes.zIndex = 768;
         attributes.hidden = NO;
@@ -168,19 +167,18 @@ NSUInteger minSectionHeaderWidth = 550/2;
             attributes.frame.size
         };
         
-        if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
-            if (self.collectionView.contentOffset.x > 0) {
-                CGRect rect = attributes.frame;
-                rect.size.width -= self.collectionView.contentOffset.x;
-                if (rect.size.width >= minSectionHeaderWidth) {
-                    attributes.frame = rect;
-                } else {
-                    rect.size.width = minSectionHeaderWidth;
-                    attributes.frame = rect;
-                }
+        NSUInteger minSectionHeaderWidth = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? minSectionHeaderWidthIpad : minSectionHeaderWidthIphone;
+        if (self.collectionView.contentOffset.x > 0) {
+            CGRect rect = attributes.frame;
+            rect.size.width -= self.collectionView.contentOffset.x;
+            if (rect.size.width >= minSectionHeaderWidth) {
+                attributes.frame = rect;
+            } else {
+                rect.size.width = minSectionHeaderWidth;
+                attributes.frame = rect;
             }
-            [self.resizableHeaderDelegate sectionHeaderResizedToWidth:attributes.frame.size.width];
         }
+        [self.resizableHeaderDelegate sectionHeaderResizedToWidth:attributes.frame.size.width];
     }
 }
 

--- a/Classes/MYNStickyFlowLayout.m
+++ b/Classes/MYNStickyFlowLayout.m
@@ -8,11 +8,6 @@
 
 #import "MYNStickyFlowLayout.h"
 
-NSUInteger minSectionHeaderHeightIpad = 114;
-NSUInteger minSectionHeaderHeightIphone = 85;
-NSUInteger minSectionHeaderWidthIpad = 550/2;
-NSUInteger minSectionHeaderWidthIphone = 339/2;
-
 @implementation MYNStickyFlowLayout
 
 - (NSArray *)layoutAttributesForElementsInRect:(CGRect)rect
@@ -119,8 +114,6 @@ NSUInteger minSectionHeaderWidthIphone = 339/2;
         // smaller of calculated position or end of section
         CGFloat finalPosition = MIN(largerYPosition, sectionMaxY);
         
-        //    NSLog(@"%.2f, %.2f, %.2f, %.2f", sectionMaxY, viewMinY, largerYPosition, finalPosition);
-        
         // update y position
         CGPoint origin = attributes.frame.origin;
         origin.y = finalPosition;
@@ -130,14 +123,13 @@ NSUInteger minSectionHeaderWidthIphone = 339/2;
             attributes.frame.size
         };
         
-        NSUInteger minSectionHeaderHeight = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? minSectionHeaderHeightIpad : minSectionHeaderHeightIphone;
         if (self.collectionView.contentOffset.y > 0) {
             CGRect rect = attributes.frame;
             rect.size.height -= self.collectionView.contentOffset.y;
-            if (rect.size.height >= minSectionHeaderHeight) {
+            if (rect.size.height >= self.minSectionHeaderHeight) {
                 attributes.frame = rect;
             } else {
-                rect.size.height = minSectionHeaderHeight;
+                rect.size.height = self.minSectionHeaderHeight;
                 attributes.frame = rect;
             }
         }
@@ -167,14 +159,13 @@ NSUInteger minSectionHeaderWidthIphone = 339/2;
             attributes.frame.size
         };
         
-        NSUInteger minSectionHeaderWidth = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? minSectionHeaderWidthIpad : minSectionHeaderWidthIphone;
         if (self.collectionView.contentOffset.x > 0) {
             CGRect rect = attributes.frame;
             rect.size.width -= self.collectionView.contentOffset.x;
-            if (rect.size.width >= minSectionHeaderWidth) {
+            if (rect.size.width >= self.minSectionHeaderWidth) {
                 attributes.frame = rect;
             } else {
-                rect.size.width = minSectionHeaderWidth;
+                rect.size.width = self.minSectionHeaderWidth;
                 attributes.frame = rect;
             }
         }
@@ -198,8 +189,6 @@ NSUInteger minSectionHeaderWidthIphone = 339/2;
     
     // larger of calculated position or end of section
     CGFloat finalPosition = MAX(smallerYPosition, sectionMinY);
-    
-//    NSLog(@"%.2f, %.2f, %.2f, %.2f", sectionMinY, viewMaxY, smallerYPosition, finalPosition);
     
     // update y position
     CGPoint origin = attributes.frame.origin;

--- a/Classes/MYNStickyFlowLayout.m
+++ b/Classes/MYNStickyFlowLayout.m
@@ -8,6 +8,8 @@
 
 #import "MYNStickyFlowLayout.h"
 
+NSUInteger minSectionHeaderHeight = 114;
+
 @implementation MYNStickyFlowLayout
 
 - (NSArray *)layoutAttributesForElementsInRect:(CGRect)rect
@@ -98,31 +100,45 @@
 
 - (void)updateHeaderAttributes:(UICollectionViewLayoutAttributes *)attributes lastCellAttributes:(UICollectionViewLayoutAttributes *)lastCellAttributes
 {
-    attributes.zIndex = 1024;
-    attributes.hidden = NO;
-
-    // last point of section minus height of header
-    CGFloat sectionMaxY = CGRectGetMaxY(lastCellAttributes.frame) - attributes.frame.size.height;
-
-    // top of the view
-    CGFloat viewMinY = CGRectGetMinY(self.collectionView.bounds) + self.collectionView.contentInset.top;
-
-    // larger of sticky position or actual position
-    CGFloat largerYPosition = MAX(viewMinY, attributes.frame.origin.y);
-    
-    // smaller of calculated position or end of section
-    CGFloat finalPosition = MIN(largerYPosition, sectionMaxY);
-
-//    NSLog(@"%.2f, %.2f, %.2f, %.2f", sectionMaxY, viewMinY, largerYPosition, finalPosition);
-
-    // update y position
-    CGPoint origin = attributes.frame.origin;
-    origin.y = finalPosition;
-
-    attributes.frame = (CGRect){
-        origin,
-        attributes.frame.size
-    };
+    if (self.scrollDirection == UICollectionViewScrollDirectionVertical) {
+        attributes.zIndex = 1024;
+        attributes.hidden = NO;
+        
+        // last point of section minus height of header
+        CGFloat sectionMaxY = CGRectGetMaxY(lastCellAttributes.frame) - attributes.frame.size.height;
+        
+        // top of the view
+        CGFloat viewMinY = CGRectGetMinY(self.collectionView.bounds) + self.collectionView.contentInset.top;
+        
+        // larger of sticky position or actual position
+        CGFloat largerYPosition = MAX(viewMinY, attributes.frame.origin.y);
+        
+        // smaller of calculated position or end of section
+        CGFloat finalPosition = MIN(largerYPosition, sectionMaxY);
+        
+        //    NSLog(@"%.2f, %.2f, %.2f, %.2f", sectionMaxY, viewMinY, largerYPosition, finalPosition);
+        
+        // update y position
+        CGPoint origin = attributes.frame.origin;
+        origin.y = finalPosition;
+        
+        attributes.frame = (CGRect){
+            origin,
+            attributes.frame.size
+        };
+        
+        if (self.collectionView.contentOffset.y > 0) {
+            CGRect rect = attributes.frame;
+            rect.size.height -= self.collectionView.contentOffset.y;
+            if (rect.size.height >= minSectionHeaderHeight) {
+                attributes.frame = rect;
+            } else {
+                rect.size.height = minSectionHeaderHeight;
+                attributes.frame = rect;
+            }
+        }
+        [self.resizableHeaderDelegate sectionHeaderResizedToHeight:attributes.frame.size.height];
+    }
 }
 
 - (void)updateFooterAttributes:(UICollectionViewLayoutAttributes *)attributes firstCellAttributes:(UICollectionViewLayoutAttributes *)firstCellAttributes

--- a/Classes/MYNStickyFlowLayout.m
+++ b/Classes/MYNStickyFlowLayout.m
@@ -122,17 +122,19 @@
             attributes.frame.size
         };
         
-        if (self.collectionView.contentOffset.y > 0) {
-            CGRect rect = attributes.frame;
-            rect.size.height -= self.collectionView.contentOffset.y;
-            if (rect.size.height >= self.minSectionHeaderHeight) {
-                attributes.frame = rect;
-            } else {
-                rect.size.height = self.minSectionHeaderHeight;
-                attributes.frame = rect;
+        if (self.minSectionHeaderHeight > 0) {
+            if (self.collectionView.contentOffset.y > 0) {
+                CGRect rect = attributes.frame;
+                rect.size.height -= self.collectionView.contentOffset.y;
+                if (rect.size.height >= self.minSectionHeaderHeight) {
+                    attributes.frame = rect;
+                } else {
+                    rect.size.height = self.minSectionHeaderHeight;
+                    attributes.frame = rect;
+                }
             }
+            [self.resizableHeaderDelegate sectionHeaderResizedToHeight:attributes.frame.size.height];
         }
-        [self.resizableHeaderDelegate sectionHeaderResizedToHeight:attributes.frame.size.height];
     } else {
         attributes.zIndex = 768;
         attributes.hidden = NO;
@@ -158,17 +160,19 @@
             attributes.frame.size
         };
         
-        if (self.collectionView.contentOffset.x > 0) {
-            CGRect rect = attributes.frame;
-            rect.size.width -= self.collectionView.contentOffset.x;
-            if (rect.size.width >= self.minSectionHeaderWidth) {
-                attributes.frame = rect;
-            } else {
-                rect.size.width = self.minSectionHeaderWidth;
-                attributes.frame = rect;
+        if (self.minSectionHeaderWidth) {
+            if (self.collectionView.contentOffset.x > 0) {
+                CGRect rect = attributes.frame;
+                rect.size.width -= self.collectionView.contentOffset.x;
+                if (rect.size.width >= self.minSectionHeaderWidth) {
+                    attributes.frame = rect;
+                } else {
+                    rect.size.width = self.minSectionHeaderWidth;
+                    attributes.frame = rect;
+                }
             }
+            [self.resizableHeaderDelegate sectionHeaderResizedToWidth:attributes.frame.size.width];
         }
-        [self.resizableHeaderDelegate sectionHeaderResizedToWidth:attributes.frame.size.width];
     }
 }
 

--- a/Classes/MYNStickyFlowLayout.m
+++ b/Classes/MYNStickyFlowLayout.m
@@ -8,7 +8,9 @@
 
 #import "MYNStickyFlowLayout.h"
 
-NSUInteger minSectionHeaderHeight = 114;
+NSUInteger minSectionHeaderHeightIpad = 114;
+NSUInteger minSectionHeaderHeightIphone = 85;
+NSUInteger minSectionHeaderWidth = 550/2;
 
 @implementation MYNStickyFlowLayout
 
@@ -127,17 +129,58 @@ NSUInteger minSectionHeaderHeight = 114;
             attributes.frame.size
         };
         
-        if (self.collectionView.contentOffset.y > 0) {
-            CGRect rect = attributes.frame;
-            rect.size.height -= self.collectionView.contentOffset.y;
-            if (rect.size.height >= minSectionHeaderHeight) {
-                attributes.frame = rect;
-            } else {
-                rect.size.height = minSectionHeaderHeight;
-                attributes.frame = rect;
+        NSUInteger minSectionHeaderHeight = UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad ? minSectionHeaderHeightIpad : minSectionHeaderHeightIphone;
+        if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+            if (self.collectionView.contentOffset.y > 0) {
+                CGRect rect = attributes.frame;
+                rect.size.height -= self.collectionView.contentOffset.y;
+                if (rect.size.height >= minSectionHeaderHeight) {
+                    attributes.frame = rect;
+                } else {
+                    rect.size.height = minSectionHeaderHeight;
+                    attributes.frame = rect;
+                }
             }
+            [self.resizableHeaderDelegate sectionHeaderResizedToHeight:attributes.frame.size.height];
         }
-        [self.resizableHeaderDelegate sectionHeaderResizedToHeight:attributes.frame.size.height];
+    } else {
+        attributes.zIndex = 768;
+        attributes.hidden = NO;
+        
+        // last point of section minus height of header
+        CGFloat sectionMaxX = CGRectGetMaxX(lastCellAttributes.frame) - attributes.frame.size.width;
+        
+        // top of the view
+        CGFloat viewMinX = CGRectGetMinX(self.collectionView.bounds) + self.collectionView.contentInset.left;
+        
+        // larger of sticky position or actual position
+        CGFloat largerXPosition = MAX(viewMinX, attributes.frame.origin.x);
+        
+        // smaller of calculated position or end of section
+        CGFloat finalPosition = MIN(largerXPosition, sectionMaxX);
+        
+        // update x position
+        CGPoint origin = attributes.frame.origin;
+        origin.x = finalPosition;
+        
+        attributes.frame = (CGRect){
+            origin,
+            attributes.frame.size
+        };
+        
+        if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+            if (self.collectionView.contentOffset.x > 0) {
+                CGRect rect = attributes.frame;
+                rect.size.width -= self.collectionView.contentOffset.x;
+                if (rect.size.width >= minSectionHeaderWidth) {
+                    attributes.frame = rect;
+                } else {
+                    rect.size.width = minSectionHeaderWidth;
+                    attributes.frame = rect;
+                }
+            }
+            [self.resizableHeaderDelegate sectionHeaderResizedToWidth:attributes.frame.size.width];
+        }
     }
 }
 

--- a/MYNStickyFlowLayout.podspec
+++ b/MYNStickyFlowLayout.podspec
@@ -9,13 +9,13 @@ Pod::Spec.new do |s|
                    Just install and set your FlowLayout Custom Class to MYNStickyFlowLayout
                    DESC
 
-  s.homepage     = "http://github.com/myntra/MYNStickyFlowLayout"
-  s.screenshot   = "https://raw.githubusercontent.com/myntra/MYNStickyFlowLayout/master/Images/Screenshot.png"
+  s.homepage     = "http://github.com/sprylab/MYNStickyFlowLayout"
+  s.screenshot   = "https://raw.githubusercontent.com/sprylab/MYNStickyFlowLayout/master/Images/Screenshot.png"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Param Aggarwal" => "paramaggarwal@gmail.com" }
   s.platform     = :ios
   s.requires_arc = true
-  s.source       = { :git => "https://github.com/myntra/MYNStickyFlowLayout.git", :tag => "v0.1.2" }
+  s.source       = { :git => "https://github.com/sprylab/MYNStickyFlowLayout.git", :tag => "v0.1.2" }
   s.source_files  = "Classes", "Classes/**/*.{h,m}"
   s.exclude_files = "Classes/Exclude"
 


### PR DESCRIPTION
Sticky headers for collection view with horizontal scrolling direction. 

Section headers can be minimized by scrolling.  Set minSectionHeaderHeight for collection view with vertical scrolling direction and/or minSectionHeaderWidth for collection view with horizontal scrolling direction to resize header by scrolling. Implement PKResizableHeaderDelegate protocol to react on size changing of header.
